### PR TITLE
Update package.json with new repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint",
     "linter"
   ],
-  "repository": "https://github.com/zyklus/atom-linter-jade",
+  "repository": "https://github.com/gitter-badger/atom-linter-jade",
   "license": "Unlicense",
   "engines": {
     "atom": ">=1.0.0 <2.0.0"


### PR DESCRIPTION
Likely needs to be redeployed with apm as the install currently does not work.

``` bash
Installing linter-jade to /Users/scott/.atom/packages ✗
Unable to download https://www.atom.io/api/packages/linter-jade/versions/0.3.2/tarball: 400 Bad Request Repository inaccessible
```
